### PR TITLE
Roots 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "coffee-script": "1.7.x",
     "mocha": "*",
-    "should": "*",
-    "roots": "3.x",
-    "roots-util": "0.0.4"
+    "roots": "3.x||4.x",
+    "roots-util": "^0.2.0",
+    "should": "*"
   },
   "peerDependencies": {
-    "roots": "3.x",
+    "roots": "3.x||4.x",
     "coveralls": "2.x",
     "istanbul": "0.3.x"
   },

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -8,12 +8,12 @@ h = new RootsUtil.Helpers(base: _path)
 
 # setup, teardown, and utils
 
-compile_fixture = (fixture_name, done) ->
+compile_fixture = (fixture_name) ->
   @public = path.join(fixture_name, 'public')
-  h.project.compile(Roots, fixture_name, -> done())
+  h.project.compile(Roots, fixture_name)
 
 before (done) ->
-  h.project.install_dependencies('*', done)
+  h.project.install_dependencies('*', -> done())
 
 after ->
   h.project.remove_folders('**/public')
@@ -22,7 +22,7 @@ after ->
 
 describe 'development', ->
 
-  before (done) -> compile_fixture.call(@, 'basic', done)
+  before (done) -> compile_fixture.call(@, 'basic').then(done)
 
   it 'ignores files listed in the ignore rules', ->
     p = path.join(@public, 'blog', 'index.html')


### PR DESCRIPTION
This PR updates `roots-ignore` dependencies on `roots` and `roots-util` to the latest versions. It also fixes test setup that was broken due to Mocha balking if `done()` is passed any non-`Error` arguments.
