### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,6 @@
     "roots-util": "^0.2.0",
     "should": "*"
   },
-  "peerDependencies": {
-    "roots": "3.x||4.x",
-    "coveralls": "2.x",
-    "istanbul": "0.3.x"
-  },
   "scripts": {
     "test": "mocha",
     "coverage": "make build; NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha; make unbuild; open coverage/lcov-report/index.html;",


### PR DESCRIPTION
I don't know if this is the best solution but the current peer dependencies mean that I have to install `coveralls` and `istanbul` to my app in order to be able to shrinkwrap, even though I don't use them.
